### PR TITLE
Generate comprehensive api documentation

### DIFF
--- a/autogpt_platform/frontend/package.json
+++ b/autogpt_platform/frontend/package.json
@@ -17,7 +17,8 @@
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
     "test-storybook": "test-storybook",
-    "test-storybook:ci": "concurrently -k -s first -n \"SB,TEST\" -c \"magenta,blue\" \"npm run build-storybook -- --quiet && npx http-server storybook-static --port 6006 --silent\" \"wait-on tcp:6006 && npm run test-storybook\""
+    "test-storybook:ci": "concurrently -k -s first -n \"SB,TEST\" -c \"magenta,blue\" \"npm run build-storybook -- --quiet && npx http-server storybook-static --port 6006 --silent\" \"wait-on tcp:6006 && npm run test-storybook\"",
+    "docs:frontend": "typedoc"
   },
   "browserslist": [
     "defaults"
@@ -111,6 +112,8 @@
     "prettier-plugin-tailwindcss": "^0.6.9",
     "storybook": "^8.4.5",
     "tailwindcss": "^3.4.17",
+    "typedoc": "^0.26.7",
+    "typedoc-plugin-markdown": "^4.3.1",
     "typescript": "^5"
   },
   "packageManager": "yarn@1.22.22+sha512.a6b2f7906b721bba3d67d4aff083df04dad64c399707841b7acf00f6b133b7ac24255f2652fa22ae3534329dc6180534e98d17432037ff6fd140556e2bb3137e",

--- a/autogpt_platform/frontend/typedoc.json
+++ b/autogpt_platform/frontend/typedoc.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://typedoc.org/schema.json",
+  "entryPoints": ["src"],
+  "tsconfig": "tsconfig.json",
+  "plugin": ["typedoc-plugin-markdown"],
+  "out": "../../docs/content/platform/api/frontend",
+  "categorizeByGroup": false,
+  "hideBreadcrumbs": true,
+  "readme": "none",
+  "entryDocument": "index.md",
+  "excludePrivate": true,
+  "excludeProtected": false,
+  "excludeInternal": true,
+  "excludeExternals": false,
+  "exclude": [
+    "**/*.stories.*",
+    "**/*.spec.*",
+    "**/*.test.*",
+    "src/stories/**",
+    "src/tests/**",
+    "**/tests/**"
+  ]
+}

--- a/docs/content/classic/api/classic.md
+++ b/docs/content/classic/api/classic.md
@@ -1,0 +1,23 @@
+---
+title: Classic AutoGPT API (Python)
+---
+
+# Classic AutoGPT API (Python)
+
+Generated from docstrings using mkdocstrings.
+
+## Application entrypoints
+
+::: autogpt.app.main
+
+::: autogpt.app.cli
+
+::: autogpt.app.config
+
+## Agent server
+
+::: autogpt.app.agent_protocol_server
+
+## Utilities
+
+::: autogpt.app.utils

--- a/docs/content/platform/api/backend.md
+++ b/docs/content/platform/api/backend.md
@@ -1,0 +1,35 @@
+---
+title: Platform Backend API (Python)
+---
+
+# Platform Backend API (Python)
+
+The sections below are generated from docstrings using mkdocstrings. They reflect the current state of the code.
+
+- For walkthroughs and examples, see the [Usage guide](./backend.usage.md).
+
+## Top-level application
+
+::: backend.app
+
+::: backend.cli
+
+## Server
+
+::: backend.server.v2.app
+
+::: backend.server.v2.store
+
+::: backend.server.v2.routes
+
+## Use cases
+
+::: backend.usecases
+
+## Blocks
+
+::: backend.blocks
+
+## Utilities
+
+::: backend.util

--- a/docs/content/platform/api/backend.usage.md
+++ b/docs/content/platform/api/backend.usage.md
@@ -1,0 +1,54 @@
+---
+title: Platform Backend Usage
+---
+
+# Platform Backend Usage
+
+## CLI
+
+Run the server in the background:
+
+```bash
+python -m backend.cli start
+```
+
+Stop the server:
+
+```bash
+python -m backend.cli stop
+```
+
+Populate the database with a sample graph and execution:
+
+```bash
+python -m backend.cli test.populate-db http://0.0.0.0:8000
+```
+
+## Programmatic usage
+
+Create a graph and execute it via the REST API:
+
+```python
+import requests
+
+server = "http://0.0.0.0:8000"
+
+# Example payload structure; adapt to your Block catalog
+graph = {
+  "name": "Sample Graph",
+  "description": "Echo input",
+  "nodes": [
+    {"id": "n1", "block_id": "input", "input_default": {}},
+    {"id": "n2", "block_id": "echo", "input_default": {"input": "Hello"}}
+  ],
+  "links": [{"source_id": "n1", "source_name": "output", "sink_id": "n2", "sink_name": "input"}]
+}
+
+r = requests.post(f"{server}/graphs", headers={"Content-Type": "application/json"}, json=graph)
+r.raise_for_status()
+graph_id = r.json()["id"]
+
+# Execute
+exec_r = requests.post(f"{server}/graphs/{graph_id}/execute", json={"input": "Hello"})
+exec_r.raise_for_status()
+```

--- a/docs/content/platform/api/frontend/USAGE.md
+++ b/docs/content/platform/api/frontend/USAGE.md
@@ -1,0 +1,65 @@
+# Frontend API Usage
+
+Below are practical examples for common public exports.
+
+## Utilities (`src/lib/utils.ts`)
+
+- Beautify strings:
+
+```ts
+import { beautifyString } from "@/lib/utils";
+
+console.log(beautifyString("openai_api_key")); // "OpenAI API Key"
+```
+
+- Safe nested get with array indices and custom separators:
+
+```ts
+import { getValue } from "@/lib/utils";
+
+const data = { user: { emails: ["a@example.com", "b@example.com"] } };
+console.log(getValue("user.emails.1", data)); // "b@example.com"
+```
+
+- Find coordinates for a new block avoiding overlaps:
+
+```ts
+import { findNewlyAddedBlockCoordinates } from "@/lib/utils";
+
+const dims = {
+  a: { x: 0, y: 0, width: 200, height: 100 },
+};
+const pos = findNewlyAddedBlockCoordinates(dims, 200, 24, 1);
+```
+
+## Hook: `useAgentGraph`
+
+```tsx
+import useAgentGraph from "@/hooks/useAgentGraph";
+
+export function AgentEditor({ flowID }: { flowID?: string }) {
+  const {
+    agentName,
+    setAgentName,
+    agentDescription,
+    setAgentDescription,
+    nodes,
+    setNodes,
+    edges,
+    setEdges,
+    requestSave,
+    requestSaveAndRun,
+    requestStopRun,
+  } = useAgentGraph(flowID);
+
+  return (
+    <div>
+      <input value={agentName} onChange={(e) => setAgentName(e.target.value)} />
+      <button onClick={requestSave}>Save</button>
+      <button onClick={requestSaveAndRun}>Save & Run</button>
+      <button onClick={requestStopRun}>Stop</button>
+      {/* render nodes/edges with React Flow */}
+    </div>
+  );
+}
+```

--- a/docs/content/platform/api/frontend/index.md
+++ b/docs/content/platform/api/frontend/index.md
@@ -1,0 +1,10 @@
+---
+title: Platform Frontend API (TypeScript)
+---
+
+# Platform Frontend API (TypeScript)
+
+- See the TypeDoc reference for all public exports below.
+- Start with the usage guide for examples and patterns: [Usage](./USAGE.md)
+
+[Open the generated API docs](./modules.md)

--- a/docs/content/platform/api/index.md
+++ b/docs/content/platform/api/index.md
@@ -1,0 +1,11 @@
+---
+title: API Reference
+---
+
+# API Reference
+
+Use the links below to navigate the public APIs in this repository.
+
+- [Platform Frontend (TypeScript)](./frontend/index.md)
+- [Platform Backend (Python)](./backend.md)
+- [Classic AutoGPT (Python)](../../classic/api/classic.md)

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -21,6 +21,7 @@ nav:
     - Using Ollama: platform/ollama.md
     - Using D-ID: platform/d_id.md
     - Blocks: platform/blocks/blocks.md
+    - API Reference: platform/api/index.md
     - Contributing:
         - Tests: platform/contributing/tests.md
   - AutoGPT Classic:
@@ -34,6 +35,7 @@ nav:
               - Search: classic/configuration/search.md
               - Voice: classic/configuration/voice.md
       - Usage: classic/usage.md
+      - API Reference: classic/api/classic.md
       - Help us improve AutoGPT:
           - Share your debug logs with us: classic/share-your-logs.md
           - Contribution guide: contributing.md
@@ -161,6 +163,12 @@ plugins:
   - search
   - git-revision-date-localized:
       enable_creation_date: true
+  - mkdocstrings:
+      handlers:
+        python:
+          paths:
+            - ../autogpt_platform/backend
+            - ../classic/original_autogpt
 
 extra:
   social:

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,5 +3,7 @@ mkdocs-material
 mkdocs-table-reader-plugin
 pymdown-extensions
 mkdocs-git-revision-date-localized-plugin
+mkdocstrings[python]
+mkdocstrings-python
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
 urllib3>=2.2.2 # not directly required, pinned by Snyk to avoid a vulnerability


### PR DESCRIPTION
### Need for changes 💡

This PR addresses the lack of comprehensive API documentation for both the frontend (TypeScript) and backend (Python) components. By integrating automated documentation generation tools, it provides up-to-date and easily accessible API references, improving developer understanding and usability of the codebase.

### Changes 🏗️

*   **Integrated TypeDoc for Frontend API**: Configured TypeDoc to generate markdown documentation for the TypeScript frontend, including a new `typedoc.json` and a `docs:frontend` script in `autogpt_platform/frontend/package.json`.
*   **Integrated mkdocstrings for Python APIs**: Configured `mkdocstrings` in `docs/mkdocs.yml` to automatically generate documentation from docstrings for both the Platform Backend and Classic AutoGPT Python modules.
*   **Added API Reference and Usage Pages**: Created new markdown files under `docs/content/platform/api/` and `docs/content/classic/api/` to serve as entry points for the generated API documentation and provide usage examples.
*   **Updated Documentation Navigation**: Modified `docs/mkdocs.yml` to include "API Reference" sections in the navigation for both Platform and Classic AutoGPT.
*   **Dependency Updates**: Added `typedoc`, `typedoc-plugin-markdown` to `autogpt_platform/frontend/package.json` and `mkdocstrings[python]`, `mkdocstrings-python` to `docs/requirements.txt`.

### Checklist 📋

#### For code changes:
- [x] I have clearly listed my changes in the PR description
- [x] I have made a test plan
- [x] I have tested my changes according to the test plan:
  - [x] **Frontend API Documentation Generation:**
    - [x] Navigate to `autogpt_platform/frontend`.
    - [x] Run `npm install`.
    - [x] Run `npm run docs:frontend`.
    - [x] Verify that markdown files are generated in `docs/content/platform/api/frontend`.
  - [x] **Python API Documentation Generation and Site Build:**
    - [x] Navigate to the project root (`/workspace`).
    - [x] Set up a Python virtual environment: `python3 -m venv .venv` and activate it: `source .venv/bin/activate`.
    - [x] Install documentation dependencies: `pip install -r docs/requirements.txt`.
    - [x] Build the documentation site: `mkdocs build` (or `mkdocs serve` to view locally).
    - [x] Verify that the documentation builds without errors.
  - [x] **Verify API Docs in Navigation:**
    - [x] Open the generated documentation site (e.g., `site/index.html` or `http://127.0.0.1:8000` if using `mkdocs serve`).
    - [x] Confirm that "API Reference" links are present under "Platform" and "AutoGPT Classic" in the navigation.
    - [x] Click on the "API Reference" links and verify that the generated frontend and backend API documentation pages load correctly, including usage examples.

#### For configuration changes:
- [ ] `.env.example` is updated or already compatible with my changes
- [ ] `docker-compose.yml` is updated or already compatible with my changes
- [x] I have included a list of my configuration changes in the PR description (under **Changes**)

---
<a href="https://cursor.com/background-agent?bcId=bc-91f96510-062e-4f98-aa8a-a1b755e44718">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-91f96510-062e-4f98-aa8a-a1b755e44718">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

